### PR TITLE
Fix broken VM expand

### DIFF
--- a/source/docker.folder/usr/local/emhttp/plugins/docker.folder/include/common-page.php
+++ b/source/docker.folder/usr/local/emhttp/plugins/docker.folder/include/common-page.php
@@ -305,7 +305,9 @@ function childrenDropdown(folder) {
             let cookieArray = cookie.split(',')
 
             for (const cookie of cookieArray) {
-                slideDownRows($(`#${cookie}`))
+                if (cookie) {
+                    slideDownRows($(`#${cookie}`))
+                }
             }
         }
 


### PR DESCRIPTION
Fix broken VM expand, button will only collapse VMs in folder, but will not expand.
Debugging for this was tough, but solution is so simple :-)

Issue reported at:
https://forums.unraid.net/topic/89702-plugin-docker-folder/?do=findComment&comment=1135065 https://forums.unraid.net/topic/89702-plugin-docker-folder/?do=findComment&comment=1142580