### PR TITLE
Fix dashboard docker folders

### DIFF
--- a/source/docker.folder/usr/local/emhttp/plugins/docker.folder/DockerFolder_Dashboard.page
+++ b/source/docker.folder/usr/local/emhttp/plugins/docker.folder/DockerFolder_Dashboard.page
@@ -209,6 +209,10 @@ function dashboard_expanded(folder) {
         $(spaces_template).insertAfter(dashboardElement.children(`.${folderType}-folder-child-${folderId}:visible:last`))
     }
 
+    // since unRAID 6.10.x the logic bellow for drawing lines does not work
+    // code is not removed in case someone wants to fix it in the future
+    return;
+
     // add line at start
     folder.child().each(function(i){
         if (i < rows) {


### PR DESCRIPTION
Fix dashboard docker folders drawing messy lines since unRAID 6.10.x
This PR removes drawing lines, I left the code there in case someone wants to fix it in the future, the logic there is messy and I could not reach something which will work in all cases without removing the lines.

## Before:
![before1](https://user-images.githubusercontent.com/1858925/190362053-24e8e0c0-896f-47f0-b8f9-229428ce6841.PNG)

![before2](https://user-images.githubusercontent.com/1858925/190362103-a3ca2977-dec7-4ce2-8a9b-f045fb5327d5.PNG)

![before3](https://user-images.githubusercontent.com/1858925/190362117-0d2cb1f5-3f9c-426d-b885-917219b0bad2.PNG)

![before4](https://user-images.githubusercontent.com/1858925/190362140-231bc2bc-0822-45e0-8879-e1a0276c18a0.PNG)

## After:
![image](https://user-images.githubusercontent.com/1858925/190362230-eafd72de-0ee4-4442-ad69-5b44ba4244fa.png)
