### PR TITLE
Add cursor pointer style to folder expand buttons

### DIFF
--- a/source/docker.folder/usr/local/emhttp/plugins/docker.folder/include/common-page.php
+++ b/source/docker.folder/usr/local/emhttp/plugins/docker.folder/include/common-page.php
@@ -18,6 +18,7 @@
         border-width: 1px;
         border-radius: 5px;
         padding: 5px;
+        cursor: pointer;
     }
     [class*="-folder-child-div-"] > tr:first-child {
         border-top: 1px solid var(--border-color);


### PR DESCRIPTION
Improve UX by setting `cursor: pointer` on the folder expand buttons to make it more obvious that they are clickable.